### PR TITLE
Fix provider call in scraping pipeline

### DIFF
--- a/src/hooks/useDeepResearch.ts
+++ b/src/hooks/useDeepResearch.ts
@@ -58,6 +58,7 @@ function useDeepResearch() {
   const taskStore = useTaskStore();
   const { smoothTextStreamType } = useSettingStore();
   const { createModelProvider, getModel } = useModelProvider();
+  const createProvider = createModelProvider;
   const { search } = useWebSearch();
   const [status, setStatus] = useState<string>("");
 
@@ -454,7 +455,7 @@ function useDeepResearch() {
 
     try {
       const queryGenerationResult = await streamText({
-        model: createModelProvider(thinkingModel),
+        model: createProvider(thinkingModel),
         prompt: generateScraperQueriesPrompt(topic),
       });
 
@@ -479,7 +480,7 @@ function useDeepResearch() {
       setStatus(t("research.common.research"));
       updateFinalReport("Stage 2: Searching Google and processing pages...");
 
-      const searchToolEnabledModel = createModelProvider(networkingModel, {
+      const searchToolEnabledModel = createProvider(networkingModel, {
         useSearchGrounding: true,
       });
 


### PR DESCRIPTION
## Summary
- alias `createProvider` to `createModelProvider`
- use `createProvider` in the scraping pipeline when generating queries and enabling search model

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6875440ec01c8323b2ec62b4c63c8dfd