### PR TITLE
Fix pipeline model initialization

### DIFF
--- a/src/hooks/useDeepResearch.ts
+++ b/src/hooks/useDeepResearch.ts
@@ -454,8 +454,8 @@ function useDeepResearch() {
 
     // Определяем модели заранее
     const { thinkingModel, networkingModel } = getModel();
-    const thinkingModelInstance = createProvider(thinkingModel);
-    const networkingModelInstance = createProvider(networkingModel, {
+    const thinkingModelInstance = await createProvider(thinkingModel);
+    const networkingModelInstance = await createProvider(networkingModel, {
       useSearchGrounding: true,
     });
 
@@ -487,6 +487,7 @@ function useDeepResearch() {
         learning: 'Waiting for search...',
         researchGoal: `Find pages with negative reviews for ${topic}.`,
         sources: [],
+        images: [],
       }));
       update(searchTasks);
 


### PR DESCRIPTION
## Summary
- ensure `createModelProvider` results are awaited in the scraping pipeline
- include `images` field when building search tasks

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68754b036ef88323b64e2c5d7038b906